### PR TITLE
Reset Password Feautre (Frontend)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import LoaderDialog from "./components/LoaderDialog";
 import {localRoutes} from "./data/constants";
 import Register from "./modules/login/Register";
 import Loading from "./components/Loading";
+import ForgotPassword from "./modules/login/ForgotPassword";
+import ResetPassword from "./modules/login/ResetPassword";
+import UpdatePasswordConfirmation from "./modules/login/UpdatePasswordConfirmation";
 
 const ContentSwitch = React.lazy(() => import("./modules/ContentSwitch"));
 const App: React.FC = () => {
@@ -26,8 +29,12 @@ const App: React.FC = () => {
                     </Suspense>
                     :
                     <Switch>
+                        <Route path={localRoutes.updatePassword} component={UpdatePasswordConfirmation} />
+                        <Route path={localRoutes.resetPassword} component={ResetPassword} />
+                        <Route path={localRoutes.forgotPassword} component={ForgotPassword} />
                         <Route path={localRoutes.login} component={Login}/>
-                        <Route component={Register}/>
+                        <Route component={Register} />
+
                     </Switch>
                 }
             </>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -39,6 +39,9 @@ export const localRoutes = {
     settings: '/admin/settings',
     test: '/test',
 
+    updatePassword: '/update-password',
+    resetPassword: '/reset-password',
+    forgotPassword: '/forgot-password',
     help: '/help',
     login: '/login',
     home: '/'
@@ -55,7 +58,8 @@ export const remoteRoutes = {
     login: url + '/api/auth/login',
     profile: url + '/api/auth/profile',
     register: url + '/api/register',
-    resetPass: url + '/reset',
+    forgotPassword: url + '/api/auth/forgot-password',
+    resetPassword: url + '/api/auth/reset-password',
     contacts: url + '/api/crm/contacts',
     contactSearch: url + '/api/crm/contact/search',
     contactById: url + '/api/crm/contacts/id',

--- a/src/modules/ContentSwitch.tsx
+++ b/src/modules/ContentSwitch.tsx
@@ -13,6 +13,7 @@ import {useSelector} from "react-redux";
 import {IState} from "../data/types";
 import MembersEditor from "./groups/members/MembersEditor";
 import {hasAnyRole} from "../data/appRoles";
+import UpdatePasswordConfirmation from "./login/UpdatePasswordConfirmation";
 
 
 
@@ -34,6 +35,7 @@ const ContentSwitch = () => {
         <Route path={localRoutes.groups} component={Groups}/>
         <Route path={localRoutes.settings} component={Settings}/>
         <Route path={localRoutes.test} component={Testing}/>
+        <Route path={localRoutes.updatePassword} component={UpdatePasswordConfirmation} />
         <Route component={NoMatch}/>
     </Switch>
 }

--- a/src/modules/login/ForgotPassword.tsx
+++ b/src/modules/login/ForgotPassword.tsx
@@ -1,0 +1,103 @@
+import React, { SyntheticEvent } from 'react';
+import {Button} from '@material-ui/core';
+import Avatar from '@material-ui/core/Avatar';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import { useLoginStyles } from './loginStyles';
+import { Form, Formik, FormikHelpers } from 'formik';
+import Link from '@material-ui/core/Link';
+import XTextInput from "../../components/inputs/XTextInput";
+import HelpIcon from '@material-ui/icons/Help';
+import { post } from "../../utils/ajax";
+import { isDebug, localRoutes, remoteRoutes } from "../../data/constants";
+import * as yup from "yup";
+import Toast from "../../utils/Toast";
+import { useHistory } from 'react-router';
+
+export default function ForgotPassword() {
+    const classes = useLoginStyles();
+    const history = useHistory();
+
+    const onSubmit = (data: any, actions: FormikHelpers<any>) => {
+        post(remoteRoutes.forgotPassword, data, resp => {
+            Toast.success(`Reset Password Link Sent to Email`)
+            const token = resp.token
+            localStorage.setItem('password_token', token)
+            console.log(resp)
+            actions.resetForm()
+        }, () => {
+            Toast.error(`Error: Message Not Set. Try Again Later`)
+            actions.setSubmitting(false)
+            actions.resetForm()
+        })
+    }
+
+    function handleBackToLogin(e: SyntheticEvent<any>) {
+        e.preventDefault()
+        history.goBack();
+    }
+
+    return (
+        <main className={classes.main}>
+            <CssBaseline/>
+            <Paper className={classes.paper}>
+                <Avatar className={classes.avatar}>
+                    <HelpIcon/>
+                </Avatar>
+                <Typography component="h1">
+                    Recover Password
+                </Typography>
+                <Formik
+                    initialValues={{
+                        "username": isDebug ? "ekastimo@gmail.com": ""
+                        //"username": ""
+                    }}
+                    validationSchema={schema}
+                    onSubmit={onSubmit}
+                >
+                    {(formState) => (
+                        <Form className={classes.form}>
+                            <XTextInput
+                                type='email'
+                                name='username'
+                                label='Email'
+                                autoComplete='off'
+                                autoFocus
+                                margin='normal'
+                            />
+                            <Button
+                                type='submit'
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                disabled={formState.isSubmitting}
+                            >
+                                Submit
+                            </Button>
+                            <Link
+                                className={classes.link}
+                                onClick={handleBackToLogin}
+                            >
+                                Back To Login Page
+                            </Link>
+                        </Form>
+                    )}
+                </Formik>
+            </Paper>
+        </main>   
+    )
+}
+
+export const schema = yup.object().shape(
+    {
+        username: yup.string().email("Invalid Email").required("Email is required")
+    }
+)
+
+
+
+
+
+

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {SyntheticEvent} from 'react';
 import {Button} from "@material-ui/core";
 import Avatar from '@material-ui/core/Avatar';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -16,6 +16,7 @@ import Toast from "../../utils/Toast";
 import XTextInput from "../../components/inputs/XTextInput";
 import {useLoginStyles} from "./loginStyles";
 import {useHistory} from "react-router";
+import Link from '@material-ui/core/Link';
 
 
 function Login() {
@@ -25,11 +26,17 @@ function Login() {
     const onSubmit = (data: any, actions: FormikHelpers<any>) => {
         post(remoteRoutes.login, data, resp => {
             dispatch(handleLogin(resp))
+            Toast.success(`Authentication succeess ${resp}`)
             history.push(localRoutes.home)
         }, () => {
-            Toast.error("Authentication failed, invalid username/password")
+            Toast.error(`Authentication failed, invalid username/password ${data}`)
             actions.setSubmitting(false)
         })
+    }
+
+    function handleForgotPassword(e: SyntheticEvent<any>) {
+        e.preventDefault()
+        history.push(localRoutes.forgotPassword);
     }
 
     return (
@@ -78,6 +85,12 @@ function Login() {
                             >
                                 Sign in
                             </Button>
+                            <Link
+                                className={classes.link}
+                                onClick={handleForgotPassword}
+                            >
+                                Forgot Password?
+                            </Link>       
                         </Form>
                     )}
                 </Formik>

--- a/src/modules/login/RegisterForm.tsx
+++ b/src/modules/login/RegisterForm.tsx
@@ -120,7 +120,7 @@ const RegisterForm = ({done}: IProps) => {
                         </Box>
                         <Divider/>
                     </Grid>
-                    <Grid item xs={12} >
+                    <Grid item xs={12} md={6} >
                         <XTextInput
                             name="firstName"
                             label="First Name"
@@ -129,7 +129,7 @@ const RegisterForm = ({done}: IProps) => {
                             margin='none'
                         />
                     </Grid>
-                    <Grid item xs={12} >
+                    <Grid item xs={12} md={6} >
                         <XTextInput
                             name="otherNames"
                             label="Other Names"

--- a/src/modules/login/ResetPassword.tsx
+++ b/src/modules/login/ResetPassword.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {Button} from '@material-ui/core';
+import Avatar from '@material-ui/core/Avatar';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import { useLoginStyles } from './loginStyles';
+import { Form, Formik, FormikHelpers } from 'formik';
+import XTextInput from "../../components/inputs/XTextInput";
+import HelpIcon from '@material-ui/icons/Help';
+import { put } from "../../utils/ajax";
+import { localRoutes, remoteRoutes } from "../../data/constants";
+import * as yup from "yup";
+import Toast from "../../utils/Toast";
+import { useHistory } from 'react-router';
+
+function ResetPassword() {
+
+    const classes = useLoginStyles();
+    const history = useHistory();
+
+    const onSubmit = (data: any, actions: FormikHelpers<any>) => {
+        const token = localStorage.getItem('password_token')
+        put(remoteRoutes.resetPassword + '/' + token, data, resp => {
+            actions.resetForm()
+            console.log(resp)
+            localStorage.removeItem('password_token')
+            history.push(localRoutes.updatePassword)
+        }, () => {
+            Toast.error("Password change was unsuccessful. Try again")
+            actions.setSubmitting(false)
+            console.log(token)
+            actions.resetForm()
+        })
+    }
+
+    return (
+        <main className={classes.main}>
+            <CssBaseline/>
+            <Paper className={classes.paper}>
+                <Avatar className={classes.avatar}>
+                    <HelpIcon/>
+                </Avatar>
+                <Typography component="h1">
+                    Update Password
+                </Typography>
+                <Formik
+                    initialValues={{
+                        "password": ""
+                    }}
+                    validationSchema={schema}
+                    onSubmit={onSubmit}
+                >
+                    {(formState) => (
+                        <Form className={classes.form}>
+                            <XTextInput
+                                type='password'
+                                name='password'
+                                label='Password'
+                                autoComplete='off'
+                                margin='normal'
+                            />
+                            <Button
+                                type='submit'
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                disabled={formState.isSubmitting}
+                            >
+                                Update Password
+                            </Button>
+                        </Form>
+                    )}
+                </Formik>
+            </Paper>
+        </main>
+    )
+}
+
+export const schema = yup.object().shape(
+    {
+        password: yup.string().required("Password is required")
+    }
+)
+
+export default ResetPassword
+
+
+
+

--- a/src/modules/login/UpdatePasswordConfirmation.tsx
+++ b/src/modules/login/UpdatePasswordConfirmation.tsx
@@ -1,0 +1,55 @@
+import React, { SyntheticEvent } from 'react';
+import Avatar from '@material-ui/core/Avatar';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import { useLoginStyles } from './loginStyles';
+import Link from '@material-ui/core/Link';
+import { localRoutes } from "../../data/constants";
+import { useHistory } from 'react-router';
+import DoneAllIcon from '@material-ui/icons/DoneAll';
+
+function UpdatePasswordConfirmation() {
+
+    const classes = useLoginStyles();
+    const history = useHistory();
+
+    function handleUpdatePassword(e: SyntheticEvent<any>) {
+        e.preventDefault()
+        history.push(localRoutes.login);
+    }
+
+    return (
+        <main className={classes.main}>
+            <CssBaseline/>
+            <Paper className={classes.paper}>
+                <Avatar className={classes.avatar}>
+                    <DoneAllIcon/>
+                </Avatar>
+                <Typography component="h1">
+                    Password Updated
+                </Typography>
+                <Typography component="p">
+                    <b>
+                        Your password has been successfully updated. Go back to the 
+                        login page to log into your account.
+                    </b>
+                </Typography>
+                <Link
+                    className={classes.link}
+                    onClick={handleUpdatePassword}
+                >
+                    Go To Login Page
+                </Link>
+                
+            </Paper>
+        </main>
+    )
+}
+
+export default UpdatePasswordConfirmation
+
+
+
+
+

--- a/src/modules/login/loginStyles.ts
+++ b/src/modules/login/loginStyles.ts
@@ -5,6 +5,7 @@ export const useLoginStyles = makeStyles((theme: Theme) =>
     createStyles({
         main: {
             width: 'auto',
+            overflowX: 'hidden',
             display: 'block', // Fix IE 11 issue.
             marginLeft: theme.spacing(3),
             marginRight: theme.spacing(3),
@@ -15,7 +16,7 @@ export const useLoginStyles = makeStyles((theme: Theme) =>
             },
         },
         paper: {
-            marginTop: theme.spacing(8),
+            marginTop: theme.spacing(14),
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
@@ -31,6 +32,14 @@ export const useLoginStyles = makeStyles((theme: Theme) =>
         },
         submit: {
             marginTop: theme.spacing(3),
+            marginBottom: theme.spacing(3),
+        },
+        link: {
+            color: theme.palette.text.secondary,
+            '&:hover': {
+                color: theme.palette.primary.main,
+            },
+            cursor: 'pointer',
         },
     }),
 );

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,6 +1,7 @@
 import {colors} from '@material-ui/core';
 
 const white = '#FFFFFF';
+const black = '#000000';
 
 const palette={
     primary: {
@@ -28,6 +29,12 @@ const palette={
     background: {
         default: '#F4F6F8',
         paper: white
+    },
+    links: {
+        white: '#FFFFFF',
+        black: '#000000',
+
     }
+
 };
 export default palette


### PR DESCRIPTION
**What does this PR do?**

- This PR adds the frontend feature that allows the user to update their password in the event that they have forgotten it, via email

**Description of tasks?**

- The user can make a request to have their password updated. 

**How can you test this manually?**

- Go to the login page `localhost:3000/#/login` and click the link "Forgot Password?"
- In the page `localhost:3000/#/forgot-password` the user can enter their email address. This will send a request to a backend endpoint that sends a unique link to that user via email. You can get the test mailURL in the `console.log()`.
- Click the link given in the mail. It will take the user to another page `localhost:3000/#/reset-password/{token}` where the user can enter their new password.
- If this request is successful, the user will be redirected to a confirmation page, `localhost:3000/#/update-password`. This page will also have a link that can allow the user to go back to the login page.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/103011382-e19d2200-454a-11eb-8e7a-c00c688db393.png)
![image](https://user-images.githubusercontent.com/68650343/103011393-e530a900-454a-11eb-9186-000b30b5bfe3.png)
![image](https://user-images.githubusercontent.com/68650343/103011399-e8c43000-454a-11eb-9d44-a57749d66f21.png)
![image](https://user-images.githubusercontent.com/68650343/103011411-ec57b700-454a-11eb-9803-e2f08a17737e.png)
