### PR TITLE
User and Team Leaders View Groups Feature

### DIFF
--- a/src/modules/contacts/details/Details.tsx
+++ b/src/modules/contacts/details/Details.tsx
@@ -120,7 +120,11 @@ const Details = (props: IProps) => {
                                         label="Summary"
                                         {...a11yProps('one')}
                                     />
-                                    <Tab value="two" label="Groups" {...a11yProps('two')} />
+                                    <Tab 
+                                        value="two" 
+                                        label="Groups" 
+                                        {...a11yProps('two')} 
+                                    />
                                 </Tabs>
                             </AppBar>
                             <Divider />
@@ -128,7 +132,7 @@ const Details = (props: IProps) => {
                                 <Info data={data} />
                             </TabPanel>
                             <TabPanel value={value} index="two">
-                                <Groups />
+                                <Groups user={profile}/>
                             </TabPanel>
                         </Grid>
                     </Grid>

--- a/src/modules/contacts/details/Groups.tsx
+++ b/src/modules/contacts/details/Groups.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {SyntheticEvent, useState} from "react";
 
 import XTable from "../../../components/table/XTable";
 import {XHeadCell} from "../../../components/table/XTableHead";
@@ -9,10 +9,13 @@ import {Box} from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 import theme from "../../../theme";
 import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
 import EditDialog from "../../../components/EditDialog";
+import {get} from "./../../../utils/ajax";
+import {isDebug, localRoutes, remoteRoutes} from "../../../data/constants";
 
 const headCells: XHeadCell[] = [
-    {name: 'id', label: 'ID', render: (dt) => trimGuid(dt)},
+    {name: 'id', label: 'ID'/*, render: (dt) => trimGuid(dt)*/},
     {name: 'name', label: 'Name'},
     {name: 'details', label: 'Details'},
     {name: 'role', label: 'Role'},
@@ -23,8 +26,34 @@ const fakeData: ITeamMember[] = [];
 for (let i = 0; i < 3; i++) {
     fakeData.push(fakeTeam())
 }
-const Groups = () => {
-    const [data, setData] = useState(fakeData);
+
+
+const groupData = (data: any, i: number, groups: ITeamMember[]) => {
+    get(remoteRoutes.groupsMembership + `/?contactId=` + data, resp => {
+        if (i === resp.length) {
+            return;
+        }
+        while (i < resp.length) {
+            const single = {
+                id: resp[i].group.id,
+                name: resp[i].group.name,
+                details: resp[i].group.groupDetails,
+                role: resp[i].role
+            }
+            groups.push(single);
+            i++;
+        }
+    })
+    return groups;
+}
+
+
+
+const Groups = (props: any) => {
+    let i = 0;
+    const groups: ITeamMember[] = [];
+    //const [data, setData] = useState(fakeData);
+    const [data, setData] = useState(groupData(props.user.contactId, i, groups));
 
     function handleAddNew() {
 

--- a/src/modules/dashboard/Dashboard.tsx
+++ b/src/modules/dashboard/Dashboard.tsx
@@ -94,7 +94,6 @@ export default function SimpleSelect() {
                     </Grid>
                 </Grid>
             </Box>
-
         </Layout>
     );
 }


### PR DESCRIPTION
**What does this PR do?**

- Adds the feature that allows the users to view the teams/groups they are part of

**Description of tasks?**

- Users are able to view teams/groups they are part of

**How can you test this manually?**

- First, the user will have to be a part of a group. This can be done by populating the `group_membership` table: `INSERT INTO 'group_membership' (groupId, contactId, role) VALUES ({groupId}, {contactId}, {role})`.
- Run server and client
-  Login and go to `http://localhost:3000/#/people/contacts/me`

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/103873478-e6340f80-50e0-11eb-8403-8ac9b0552ece.png)
