### PR TITLE
User Group View Feature

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -18,6 +18,8 @@ import MailIcon from '@material-ui/icons/Mail';
 import HiddenJs from "@material-ui/core/Hidden/HiddenJs";
 import {getInitials} from "../utils/stringHelpers";
 import {handleLogout} from "../data/coreActions";
+import {useHistory} from "react-router";
+import {localRoutes} from "./../data/constants";
 
 export const BarView = (props: any) => {
     const profile = useSelector((state: IState) => state.core.user)
@@ -25,9 +27,14 @@ export const BarView = (props: any) => {
     const [dialogOpen, setDialogOpen] = useState(false);
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const menuOpen = Boolean(anchorEl);
+    const history = useHistory();
 
     function openDialog() {
         setDialogOpen(true)
+    }
+
+    function handleProfile() {
+        history.push(`${localRoutes.contacts}/${profile.id}`);
     }
 
     function doLogout() {
@@ -78,7 +85,7 @@ export const BarView = (props: any) => {
             open={menuOpen}
             onClose={handleCloseMenu}
         >
-            <MenuItem onClick={openDialog}>Profile</MenuItem>
+            <MenuItem onClick={handleProfile}>Profile</MenuItem>
             <MenuItem onClick={doLogout}>Logout</MenuItem>
         </Menu>
         <Dialog onClose={closeDialog} aria-labelledby="simple-dialog-title" open={dialogOpen}>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -86,6 +86,7 @@ export const remoteRoutes = {
 
   groupsCategoriesById: url + "/api/groups/category/{id}", // Added by Daniel
   groupsMemberships: url + "/api/groups/member", // Added by Daniel
+  groupsMembership: url + '/api/groups/member',
 
   contactsCompany: url + "/api/crm/contact/company",
   contactsAvatar: url + "/api/crm/contact/avatar",

--- a/src/modules/contacts/details/Details.tsx
+++ b/src/modules/contacts/details/Details.tsx
@@ -77,7 +77,6 @@ const Details = (props: IProps) => {
     const classes = useStyles()
     const dispatch = useDispatch();
     const data: IContact | undefined = useSelector((state: any) => state.crm.selected)
-
     const [loading, setLoading] = useState<boolean>(true)
     const [value, setValue] = React.useState('one');
 
@@ -124,7 +123,7 @@ const Details = (props: IProps) => {
                                 <Info data={data}/>
                             </TabPanel>
                             <TabPanel value={value} index="two">
-                                <Groups/>
+                                <Groups id={contactId}/>
                             </TabPanel>
                         </Grid>
                     </Grid>

--- a/src/modules/contacts/details/Groups.tsx
+++ b/src/modules/contacts/details/Groups.tsx
@@ -1,5 +1,4 @@
 import React, {useState} from "react";
-
 import XTable from "../../../components/table/XTable";
 import {XHeadCell} from "../../../components/table/XTableHead";
 import Grid from '@material-ui/core/Grid';
@@ -7,12 +6,12 @@ import {fakeTeam, ITeamMember} from "../types";
 import {trimGuid} from "../../../utils/stringHelpers";
 import {Box} from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import theme from "../../../theme";
 import Button from "@material-ui/core/Button";
-import EditDialog from "../../../components/EditDialog";
+import {get} from "./../../../utils/ajax";
+import {remoteRoutes} from "../../../data/constants";
 
 const headCells: XHeadCell[] = [
-    {name: 'id', label: 'ID', render: (dt) => trimGuid(dt)},
+    {name: 'id', label: 'ID'/*, render: (dt) => trimGuid(dt)*/},
     {name: 'name', label: 'Name'},
     {name: 'details', label: 'Details'},
     {name: 'role', label: 'Role'},
@@ -23,9 +22,36 @@ const fakeData: ITeamMember[] = [];
 for (let i = 0; i < 3; i++) {
     fakeData.push(fakeTeam())
 }
-const Groups = () => {
-    const [data, setData] = useState(fakeData);
 
+
+
+const groupData = (data: any, i: number, groups: ITeamMember[]) => {
+    get(remoteRoutes.groupsMembership + `/?contactId=` + data, resp => {
+        if (i === resp.length) {
+            return;
+        }
+        while (i < resp.length) {
+            const single = {
+                id: resp[i].group.id,
+                name: resp[i].group.name,
+                details: resp[i].group.groupDetails,
+                role: resp[i].role
+            }
+            groups.push(single);
+            i++;
+        }
+    })
+    return groups;
+}
+
+
+
+const Groups = (props: any) => {
+    //const [data, setData] = useState(fakeData);
+    let i = 0;
+    const groups: ITeamMember[] = [];
+    const [data, setData] = useState(groupData(props.id, i, groups));
+    
     function handleAddNew() {
 
     }
@@ -49,7 +75,7 @@ const Groups = () => {
                 </Box>
             </Grid>
             <Grid item xs={12}>
-                <XTable
+                <XTable 
                     headCells={headCells}
                     data={data}
                     initialRowsPerPage={10}


### PR DESCRIPTION
**What does this PR do?**

- Adds the feature that allows the users to view the teams/groups they are part of.

**Description of tasks?**

- Users are able to view teams/groups they are part of

**How can you test this manually?**

- First, the user will have to be a part of a group. This can be done by populating the `group_membership` table: `INSERT INTO 'group_membership' (groupId, contactId, role) VALUES ({groupId}, {contactId}, {role})`.
- Run server and client
-  Login and go to `http://localhost:3000/#/people/contacts/{contactId}`

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/104130157-485e7000-5380-11eb-9950-319798ee34e7.png)
