### PR TITLE
View User Groups Feature

### DIFF
--- a/src/components/table/XTable.tsx
+++ b/src/components/table/XTable.tsx
@@ -150,7 +150,7 @@ export default function XTable(props: XTableProps) {
                                                     tabIndex={-1}
                                                     key={row[primaryKey]}
                                                     selected={isItemSelected}
-                                                    style={{backgroundColor: isEven(index) ? 'white' : grey[50]}}
+                                                    style={{backgroundColor: isEven(index) ? 'white' : grey[50], cursor: 'pointer'}}
                                                 >
                                                     {
                                                         useCheckbox &&

--- a/src/modules/contacts/details/Groups.tsx
+++ b/src/modules/contacts/details/Groups.tsx
@@ -1,5 +1,4 @@
-import React, {SyntheticEvent, useState} from "react";
-
+import React, {useState} from "react";
 import XTable from "../../../components/table/XTable";
 import {XHeadCell} from "../../../components/table/XTableHead";
 import Grid from '@material-ui/core/Grid';
@@ -7,12 +6,11 @@ import {fakeTeam, ITeamMember} from "../types";
 import {trimGuid} from "../../../utils/stringHelpers";
 import {Box} from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import theme from "../../../theme";
 import Button from "@material-ui/core/Button";
-import Typography from "@material-ui/core/Typography";
 import EditDialog from "../../../components/EditDialog";
 import {get} from "./../../../utils/ajax";
-import {isDebug, localRoutes, remoteRoutes} from "../../../data/constants";
+import {localRoutes, remoteRoutes} from "../../../data/constants";
+import {useHistory} from "react-router";
 
 const headCells: XHeadCell[] = [
     {name: 'id', label: 'ID'/*, render: (dt) => trimGuid(dt)*/},
@@ -26,7 +24,6 @@ const fakeData: ITeamMember[] = [];
 for (let i = 0; i < 3; i++) {
     fakeData.push(fakeTeam())
 }
-
 
 const groupData = (data: any, i: number, groups: ITeamMember[]) => {
     get(remoteRoutes.groupsMembership + `/?contactId=` + data, resp => {
@@ -48,15 +45,20 @@ const groupData = (data: any, i: number, groups: ITeamMember[]) => {
 }
 
 
-
 const Groups = (props: any) => {
     let i = 0;
     const groups: ITeamMember[] = [];
+    const history = useHistory();
     //const [data, setData] = useState(fakeData);
     const [data, setData] = useState(groupData(props.user.contactId, i, groups));
+    
 
     function handleAddNew() {
 
+    }
+
+    const handleView = (dt: any) => {
+        history.push(localRoutes.groups + '/' + dt);
     }
 
     return (
@@ -82,11 +84,15 @@ const Groups = (props: any) => {
                     headCells={headCells}
                     data={data}
                     initialRowsPerPage={10}
+                    handleSelection={handleView}
                 />
             </Grid>
-            {/*/<EditDialog open={} onClose={} title={}></EditDialog>*/}
         </Grid>
     );
 }
 
 export default Groups
+
+
+
+

--- a/src/modules/contacts/types.ts
+++ b/src/modules/contacts/types.ts
@@ -191,6 +191,28 @@ export interface ITeamMember {
     role: TeamRole
 }
 
+export interface IGroup {
+    id: string
+    name: string
+    privacy: string
+    details: string
+    categoryId: string
+    parentId: string
+    category: {
+        id: string
+        name: string
+    }
+    parent: {
+        id: string
+        name: string
+    }
+    placeId: string
+    longitude: string
+    latitude: string
+    geoCoordinates: string 
+    freeForm: string
+}
+
 export interface IContactsFilter {
     query?: string
     skip?: string


### PR DESCRIPTION
**What does this PR do?**

- This PR adds the feature that allows users to view the details of groups they are a member/leader of.

**Description of tasks?**

- Users can go to their profile to view a list of groups they are a member of. With this PR, when they click on one of the group rows, they will be routed to `localhost:3000/#/people/groups/{groupId}` where they will see details of the selected group.

**How can you test this manually?**

- Go to the user `profile` and open the `groups` tab. Click on one of the rows containing a group. User will be directed to a page with a detailed description of the selected group.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/105170970-c237eb80-5b2e-11eb-88e0-f8dc9fa5e527.png)

