### PR TITLE
Edit Group Detials

### DIFF
--- a/src/components/table/XTable.tsx
+++ b/src/components/table/XTable.tsx
@@ -214,3 +214,7 @@ export default function XTable(props: XTableProps) {
         </div>
     );
 }
+
+
+
+

--- a/src/modules/contacts/details/Groups.tsx
+++ b/src/modules/contacts/details/Groups.tsx
@@ -1,5 +1,5 @@
-import React, {SyntheticEvent, useState} from "react";
-
+import React, {useState} from "react";
+import Toast from '../../../utils/Toast';
 import XTable from "../../../components/table/XTable";
 import {XHeadCell} from "../../../components/table/XTableHead";
 import Grid from '@material-ui/core/Grid';
@@ -9,17 +9,15 @@ import {Box} from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 import theme from "../../../theme";
 import Button from "@material-ui/core/Button";
-import Typography from "@material-ui/core/Typography";
-import EditDialog from "../../../components/EditDialog";
+
 import {get} from "./../../../utils/ajax";
-import {isDebug, localRoutes, remoteRoutes} from "../../../data/constants";
+import { remoteRoutes } from "../../../data/constants";
 
 const headCells: XHeadCell[] = [
     {name: 'id', label: 'ID'/*, render: (dt) => trimGuid(dt)*/},
     {name: 'name', label: 'Name'},
     {name: 'details', label: 'Details'},
     {name: 'role', label: 'Role'},
-
 ];
 
 const fakeData: ITeamMember[] = [];
@@ -48,15 +46,21 @@ const groupData = (data: any, i: number, groups: ITeamMember[]) => {
 }
 
 
-
 const Groups = (props: any) => {
     let i = 0;
     const groups: ITeamMember[] = [];
+    const [selected, setSelected] = useState<any | null>(null)
+    const [dialog, setDialog] = useState<any | null>(null)
     //const [data, setData] = useState(fakeData);
-    const [data, setData] = useState(groupData(props.user.contactId, i, groups));
+    const [data, setData] = useState(groupData(props.user.contactId, i, groups))
 
     function handleAddNew() {
 
+    }
+
+    const handleClose = () => {
+        setSelected(null)
+        setDialog(false)
     }
 
     return (
@@ -84,9 +88,12 @@ const Groups = (props: any) => {
                     initialRowsPerPage={10}
                 />
             </Grid>
-            {/*/<EditDialog open={} onClose={} title={}></EditDialog>*/}
         </Grid>
     );
 }
 
 export default Groups
+
+
+
+

--- a/src/modules/groups/editors/GroupEditor.tsx
+++ b/src/modules/groups/editors/GroupEditor.tsx
@@ -32,7 +32,7 @@ const schema = yup.object().shape(
         name: reqString,
         privacy: reqString,
         details: reqString,
-        location: reqObject,
+        //location: reqObject,
         category: reqObject
     }
 )


### PR DESCRIPTION
**What does this PR do?**

- This PR adds the feature that allows only team leaders to edit groups that they are leaders of.

**Description of tasks?**

- Only team leaders can edit the group details of groups that they are leaders of.

**How can I test this manually?**

- Go to Groups in navigation menu and select group you are a team leader of 
- Edit button will only be available if `role: [..., "GROUP_EDIT", ...]` and the logged in user is the team lead of the group 
- Enter required data and click submit.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/105337376-63847780-5beb-11eb-9ead-bace9470170f.png)
![image](https://user-images.githubusercontent.com/68650343/105337388-6717fe80-5beb-11eb-818f-b3d6a688431c.png)
