### PR TITLE
Ref-009 View User Details Feature

### DIFF
--- a/src/components/DataList.tsx
+++ b/src/components/DataList.tsx
@@ -14,16 +14,17 @@ import TableBody from "@material-ui/core/TableBody";
 import {XHeadCell} from "./table/XTableHead";
 import IconButton from '@material-ui/core/IconButton';
 import EditIcon from '@material-ui/icons/Edit';
-import Typography from "@material-ui/core/Typography";
+import VisibilityIcon from '@material-ui/icons/Visibility';
 
 interface IProps {
     data: any[]
     toMobileRow: (data: any) => IMobileRow
     columns: XHeadCell[],
-    onEditClick?: (data:any) => any
+    onEditClick?: (data:any) => any,
+    onViewClick?: (data: any)=> any,
 }
 
-const DataList = ({data, columns, toMobileRow, onEditClick}: IProps) => {
+const DataList = ({data, columns, toMobileRow, onEditClick, onViewClick}: IProps) => {
     const theme = useTheme();
     const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
     return (
@@ -34,7 +35,7 @@ const DataList = ({data, columns, toMobileRow, onEditClick}: IProps) => {
                         data.map((row: any) => {
                             const mobileRow = toMobileRow(row)
                             return <Fragment key={row.id}>
-                                <ListItem alignItems="flex-start" button disableGutters onClick={()=>onEditClick&&onEditClick(row)}>
+                                <ListItem alignItems="flex-start" disableGutters>
                                     <ListItemAvatar>
                                         {mobileRow.avatar}
                                     </ListItemAvatar>
@@ -42,6 +43,30 @@ const DataList = ({data, columns, toMobileRow, onEditClick}: IProps) => {
                                         primary={mobileRow.primary}
                                         secondary={mobileRow.secondary}
                                     />
+                                    {
+                                        onViewClick &&
+                                        <IconButton
+                                            onClick={()=>onViewClick&&onViewClick(row)}
+                                            size='medium'
+                                            color="primary"
+                                            aria-label="edit"
+                                            component="span"
+                                            >
+                                            <VisibilityIcon/>
+                                        </IconButton>
+                                    }
+                                    {
+                                        onEditClick &&
+                                            <IconButton
+                                            onClick={()=>onEditClick&&onEditClick(row)}
+                                            size='medium'
+                                            color="primary"
+                                            aria-label="edit"
+                                            component="span"
+                                            >
+                                            <EditIcon/>
+                                        </IconButton>
+                                    }
                                 </ListItem>
                                 <Divider component="li"/>
                             </Fragment>
@@ -61,9 +86,16 @@ const DataList = ({data, columns, toMobileRow, onEditClick}: IProps) => {
                                     >{it.label}</TableCell>)
                             }
                             {
+                                onViewClick &&
+                                <TableCell
+                                    align='center'
+                                    component='th'
+                                >&nbsp;</TableCell>
+                            }
+                            {
                                 onEditClick &&
                                 <TableCell
-                                    align='right'
+                                    align='center'
                                     component='th'
                                 >&nbsp;</TableCell>
                             }
@@ -83,11 +115,25 @@ const DataList = ({data, columns, toMobileRow, onEditClick}: IProps) => {
                                     ))
                                 }
                                 {
+                                    onViewClick &&
+                                    <TableCell
+                                        align='center'>
+                                        <IconButton
+                                            size='medium'
+                                            color="primary"
+                                            aria-label="edit"
+                                            component="span"
+                                            onClick={()=>onViewClick&&onViewClick(row)}>
+                                            <VisibilityIcon/>
+                                        </IconButton>
+                                    </TableCell>
+                                }
+                                {
                                     onEditClick &&
                                     <TableCell
-                                        align='right'>
+                                        align='center'>
                                         <IconButton
-                                            size='small'
+                                            size='medium'
                                             color="primary"
                                             aria-label="edit"
                                             component="span"

--- a/src/modules/admin/users/Users.tsx
+++ b/src/modules/admin/users/Users.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import Layout from "../../../components/layout/Layout";
+import { useHistory } from 'react-router';
 import {XHeadCell} from "../../../components/table/XTableHead";
 import {Avatar} from "@material-ui/core";
 import Typography from "@material-ui/core/Typography";
@@ -8,7 +9,7 @@ import Header from "../../contacts/Header";
 import DataList from "../../../components/DataList";
 import {AddFabButton} from "../../../components/EditIconButton";
 import {search} from "../../../utils/ajax";
-import {remoteRoutes} from "../../../data/constants";
+import {localRoutes, remoteRoutes} from "../../../data/constants";
 import {hasValue} from "../../../components/inputs/inputHelpers";
 import PersonIcon from "@material-ui/icons/Person";
 import Hidden from "@material-ui/core/Hidden";
@@ -93,6 +94,7 @@ const toMobile = (data: any): IMobileRow => {
 
 
 const Users = () => {
+    const history = useHistory();
     const [filter, setFilter] = useState<any>({})
     const [loading, setLoading] = useState<boolean>(true)
     const [data, setData] = useState<any[]>([])
@@ -124,6 +126,10 @@ const Users = () => {
         }
         setSelected(toEdit)
         setDialog(true)
+    }
+
+    const handleView = (dt: any) => {
+        history.push(`${localRoutes.contacts}/${dt.id}`)  
     }
 
     const handleComplete = (dt: any) => {
@@ -162,6 +168,7 @@ const Users = () => {
                             toMobileRow={toMobile}
                             columns={columns}
                             onEditClick={handleEdit}
+                            onViewClick={handleView}
                         />
                 }
             </Box>


### PR DESCRIPTION
** What does this PR do? **

- Adds the feature that allows admins to view the details of a user.

** Description of tasks? **

- Admin users can now view the details of a user.

** How can you test this manually? **

- Select `Admin` in the sidebar, and click `Users` from the dropdown menu.
- There is a new column that has a button that links to `localhost:3000/#/people/contacts/{id}`

** Screenshot(s) **

![image](https://user-images.githubusercontent.com/68650343/105993030-e8253900-60b6-11eb-8277-642b017a5c23.png)
![image](https://user-images.githubusercontent.com/68650343/105993043-ece9ed00-60b6-11eb-87d1-0ad2ee9e453c.png)
