### PR TITLE
Ref-011 Activate/Block User Feature

### DIFF
--- a/src/modules/admin/users/UserEditor.tsx
+++ b/src/modules/admin/users/UserEditor.tsx
@@ -5,7 +5,7 @@ import {FormikHelpers} from "formik";
 import Grid from "@material-ui/core/Grid";
 import XForm from "../../../components/forms/XForm";
 import XTextInput from "../../../components/inputs/XTextInput";
-
+import XCheckBoxInput from '../../../components/inputs/XCheckBoxInput';
 import {remoteRoutes, rolesList} from "../../../data/constants";
 import {XRemoteSelect} from "../../../components/inputs/XRemoteSelect";
 import {handleSubmission, ISubmission} from "../../../utils/formHelpers";
@@ -37,7 +37,7 @@ const editSchema = yup.object().shape(
         roles: reqArray,
     }
 )
-const initialValues = {contact: null, password: '', roles: []}
+const initialValues = {contact: null, password: null, roles: [], isActive: true}
 const UserEditor = ({data, isNew, done, onDeleted, onCancel}: IProps) => {
 
     const [loading, setLoading] = useState<boolean>(false)
@@ -47,7 +47,8 @@ const UserEditor = ({data, isNew, done, onDeleted, onCancel}: IProps) => {
             ...values,
             contactId: values.contact.id,
             password: values.password,
-            roles: cleanComboValue(values.roles)
+            roles: cleanComboValue(values.roles),
+            isActive: values.isActive
         }
         const submission: ISubmission = {
             url: remoteRoutes.users,
@@ -111,7 +112,15 @@ const UserEditor = ({data, isNew, done, onDeleted, onCancel}: IProps) => {
                         name="password"
                         label="Password"
                         type="password"
+                        value="Hello"
                         variant='outlined'
+                        autoComplete='off'
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <XCheckBoxInput 
+                        name="isActive"
+                        label="Do you want to activate this user?"
                     />
                 </Grid>
             </Grid>

--- a/src/modules/admin/users/Users.tsx
+++ b/src/modules/admin/users/Users.tsx
@@ -19,6 +19,16 @@ import Chip from '@material-ui/core/Chip';
 
 const columns: XHeadCell[] = [
     {
+        name: 'isActive',
+        label: 'Status',
+        render: (value) => 
+        <Chip 
+            label={value ? "Active" : "Inactive"} 
+            color="secondary" 
+            size="small"
+        />
+    },
+    {
         name: 'avatar',
         label: 'Avatar',
         render: (data) => {
@@ -73,7 +83,10 @@ const toMobile = (data: any): IMobileRow => {
                 alt="Avatar"
                 src={data.avatar}
             /> : <Avatar><PersonIcon/></Avatar>,
-        primary: data.fullName,
+        primary: <>
+            {`${data.fullName}\t`}
+            <Chip label={data.isActive ? "Active" : "Inactive"} color="secondary" size="small"/>
+            </>,
         secondary: <>
             <Typography variant='caption' color='textSecondary'>{data.username}</Typography>
             <div>{data.roles?.map((it: any) => (
@@ -115,12 +128,13 @@ const Users = () => {
     }
 
     const handleEdit = (dt: any) => {
-        const {id, username, contactId, fullName, roles} = dt
+        const {id, username, contactId, fullName, roles, isActive} = dt
         const toEdit = {
             id,
             username,
             roles: [...roles],
-            contact: {id: contactId, label: fullName}
+            contact: {id: contactId, label: fullName},
+            isActive: isActive,
         }
         setSelected(toEdit)
         setDialog(true)


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows admins to activate and block users.

**Description of tasks?**

- Admins are now able to approve and block users. Blocked user will be unable to login with their credentials

**How can you test this manually?**

- Click on `Admin` in sidebar. In the dropdown menu, select `Users`. 
- Click edit icon. Checkbox will be available to activate or block users.
- Make changes and select **submit**
- _Checkbox initial value will be the user's current status_  

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/106252095-e5495600-6226-11eb-8da1-1f81d8c53f0b.png)
![image](https://user-images.githubusercontent.com/68650343/106252111-eb3f3700-6226-11eb-8bd8-b9e965426ce4.png)
![image](https://user-images.githubusercontent.com/68650343/106252119-ef6b5480-6226-11eb-8563-2e03aed9bdca.png)
