### PR TITLE
Ref015 Create Member and Assign To MC

### DIFF
--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -9,7 +9,7 @@ import Grid from '@material-ui/core/Grid';
 import Filter from "./Filter";
 import ContactLink from "../../components/ContactLink";
 import { search } from "../../utils/ajax";
-import { localRoutes, remoteRoutes } from "../../data/constants";
+import { appRoles, localRoutes, remoteRoutes } from "../../data/constants";
 import Loading from "../../components/Loading";
 import Box from "@material-ui/core/Box";
 import Header from "./Header";
@@ -33,6 +33,8 @@ import { crmConstants, ICrmState } from "../../data/contacts/reducer";
 import { printBirthday } from "../../utils/dateHelpers";
 import GroupLink from "../../components/GroupLink";
 import XAvatar from "../../components/XAvatar";
+import { hasAnyRole } from "../../data/appRoles";
+import { IState } from "../../data/types";
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -88,6 +90,7 @@ const Contacts = () => {
     const { data, loading }: ICrmState = useSelector((state: any) => state.crm)
     const [showFilter, setShowFilter] = useState(!isSmall);
     const [filter, setFilter] = useState<IContactsFilter>({});
+    const user = useSelector((state: IState) => state.core.user);
 
     const classes = useStyles();
     useEffect(() => {
@@ -152,7 +155,7 @@ const Contacts = () => {
         <Navigation>
             <Box p={1} className={classes.root}>
                 <Header
-                    onAddNew={handleNew}
+                    onAddNew={hasAnyRole(user, [appRoles.roleCrmEdit]) ? handleNew : undefined}
                     onFilterToggle={handleFilterToggle}
                     title='Contacts'
                     onChange={handleNameSearch}
@@ -202,9 +205,14 @@ const Contacts = () => {
                     <EditDialog open={showFilter} onClose={() => setShowFilter(false)} title={filterTitle}>
                         {filterComponent}
                     </EditDialog>
-                    <Fab aria-label='add-new' className={classes.fab} color='primary' onClick={handleNew}>
-                        <AddIcon />
-                    </Fab>
+                    {
+                        hasAnyRole(user, [appRoles.roleCrmEdit]) ? 
+                            <Fab aria-label='add-new' className={classes.fab} color='primary' onClick={handleNew}>
+                                <AddIcon />
+                            </Fab>
+                        :
+                            undefined
+                    }
                 </Hidden>
             </Box>
             <EditDialog title={createTitle} open={createDialog} onClose={closeCreateDialog}>

--- a/src/modules/contacts/Header.tsx
+++ b/src/modules/contacts/Header.tsx
@@ -10,7 +10,7 @@ import theme from "../../theme";
 
 interface IProps {
     title?: string
-    onAddNew: () => any
+    onAddNew?: () => any
     onFilterToggle?: () => any
     onChange?: (v: string) => any
 }
@@ -33,6 +33,8 @@ const Header = ({onAddNew, onFilterToggle,onChange, title}: IProps) => {
                     </Box>
                     <Hidden xsDown>
                         <Box flexShrink={0} ml={1}>
+                        {
+                            onAddNew &&
                             <Button
                                 variant="contained"
                                 color="primary"
@@ -42,6 +44,7 @@ const Header = ({onAddNew, onFilterToggle,onChange, title}: IProps) => {
                             >
                                 New&nbsp;&nbsp;
                             </Button>
+                        }
                         </Box>
                     </Hidden>
                 </Box>

--- a/src/modules/contacts/details/Details.tsx
+++ b/src/modules/contacts/details/Details.tsx
@@ -132,7 +132,7 @@ const Details = (props: IProps) => {
                                 <Info data={data} />
                             </TabPanel>
                             <TabPanel value={value} index="two">
-                                <Groups user={profile}/>
+                                <Groups contactId={contactId}/>
                             </TabPanel>
                         </Grid>
                     </Grid>

--- a/src/modules/contacts/details/Groups.tsx
+++ b/src/modules/contacts/details/Groups.tsx
@@ -1,30 +1,20 @@
 import React, {useState} from "react";
-import Toast from '../../../utils/Toast';
 import XTable from "../../../components/table/XTable";
 import {XHeadCell} from "../../../components/table/XTableHead";
 import Grid from '@material-ui/core/Grid';
-import {fakeTeam, ITeamMember} from "../types";
-import {trimGuid} from "../../../utils/stringHelpers";
+import {ITeamMember} from "../types";
 import {Box} from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import theme from "../../../theme";
 import Button from "@material-ui/core/Button";
-
 import {get} from "./../../../utils/ajax";
 import { remoteRoutes } from "../../../data/constants";
 
 const headCells: XHeadCell[] = [
-    {name: 'id', label: 'ID'/*, render: (dt) => trimGuid(dt)*/},
+    {name: 'id', label: 'ID'},
     {name: 'name', label: 'Name'},
     {name: 'details', label: 'Details'},
     {name: 'role', label: 'Role'},
 ];
-
-const fakeData: ITeamMember[] = [];
-for (let i = 0; i < 3; i++) {
-    fakeData.push(fakeTeam())
-}
-
 
 const groupData = (data: any, i: number, groups: ITeamMember[]) => {
     get(remoteRoutes.groupsMembership + `/?contactId=` + data, resp => {
@@ -51,8 +41,7 @@ const Groups = (props: any) => {
     const groups: ITeamMember[] = [];
     const [selected, setSelected] = useState<any | null>(null)
     const [dialog, setDialog] = useState<any | null>(null)
-    //const [data, setData] = useState(fakeData);
-    const [data, setData] = useState(groupData(props.user.contactId, i, groups))
+    const [data, setData] = useState(groupData(props.contactId, i, groups))
 
     function handleAddNew() {
 


### PR DESCRIPTION
**What does this PR do?**

- This PR puts restrictions on the "create member" functionality and fixes issues with viewing a user's groups

**Description of tasks?**

- With this PR, only MC admins can create members and assign these members to a `Location` and `MC`.
- This PR contains fixes to the feature that allows users to view the groups that they belong to.

**How can you test it manually?**

- Go to `People` on the navigation menu, and select `Contacts`
- The add button will only be available if the logged in user has the role `CRM_EDIT`

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/106746101-1bc20f00-6633-11eb-91f5-3b09aa174844.png)
