### PR TITLE
As a church member, I can view generic church metrics

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -24,6 +24,14 @@ export const appRoles = {
 
 export const rolesList = Object.values(appRoles);
 
+export const eventsCategories = {
+  garage: "Garage",
+  evangelism: "Evangelism",
+  wedding: "Wedding",
+  baptism: "Baptism",
+  mc: "MC Meeting"
+}
+
 export const redux = {
   doLogin: "DO_LOGIN",
   doLogout: "DO_LOGOUT",

--- a/src/modules/contacts/details/groups/ContactGroups.tsx
+++ b/src/modules/contacts/details/groups/ContactGroups.tsx
@@ -26,21 +26,14 @@ const ContactGroups = ({ isOwnProfile, contactId, contact }: IProps) => {
   useEffect(() => {
     get(remoteRoutes.groupsMembership + `/?contactId=` + contactId, resp => {
       const groups: ITeamMember[] = [];
-      // TODO @mariam, please change this to user array.map
-      let i = 0;
-      if (i === resp.length) {
-        return;
-      }
-      while (i < resp.length) {
-        const single = {
-          id: resp[i].group.id,
-          name: resp[i].group.name,
-          details: resp[i].group.groupDetails,
-          role: resp[i].role
-        };
-        groups.push(single);
-        i++;
-      }
+      resp.map((it: any) => {
+        groups.push({
+          id: it.group.id,
+          name: it.group.name,
+          details: it.group.groupDetails,
+          role: it.role
+        })
+      })
       setData(groups);
     });
   }, [contactId]);

--- a/src/modules/dashboard/DashboardData.tsx
+++ b/src/modules/dashboard/DashboardData.tsx
@@ -1,0 +1,160 @@
+import { Grid } from '@material-ui/core';
+import { Build, ChildFriendly, EmojiPeople, Grain, Info, LocalFlorist, Money, People, Restore } from '@material-ui/icons';
+import React, { useEffect, useState } from 'react';
+import { eventsCategories } from '../../data/constants';
+import { printInteger, printMoney } from '../../utils/numberHelpers';
+import { IEvent } from '../events/types';
+import UsersByDevice from './UsersByDevice';
+import Widget from './Widget';
+
+interface IProps {
+  currWeekEvents: IEvent[];
+  prevWeekEvents: IEvent[];
+}
+
+const DashboardData = ({ currWeekEvents,  prevWeekEvents }: IProps) => {
+
+  const [giving, setGiving] = useState<number>(0)
+  const [prevGiving, setPrevGiving] = useState<number>(0)
+  const [att, setAtt] = useState<number>(0)
+  const [prevAtt, setPrevAtt] = useState<number>(0)
+  const [mcAtt, setMcAtt] = useState<number>(0)
+  const [prevMcAtt, setPrevMcAtt] = useState<number>(0)
+  const [salvation, setSalvation] = useState<number>(0)
+  const [prevSalvation, setPrevSalvation] = useState<number>(0)
+  const [mechanics, setMechanics] = useState<number>(0)
+  const [prevMechanics, setPrevMechanics] = useState<number>(0)
+  const [baptism, setBaptism] = useState<number>(0)
+  const [prevBaptism, setPrevBaptism] = useState<number>(0)
+  const [recom, setRecom] = useState<number>(0)
+  const [prevRecom, setPrevRecom] = useState<number>(0)
+  const [babies, setBabies] = useState<number>(20)
+  const [prevBabies, setPrevBabies] = useState<number>(10)
+  const [weddings, setWeddings] = useState<number>(0)
+  const [prevWeddings, setPrevWeddings] = useState<number>(0)
+
+  useEffect(() => {
+    currWeekEvents.map(it => (getValues(it, true)))
+    prevWeekEvents.map(it => (getValues(it, false)))
+  }, [currWeekEvents.length])
+
+  const getValues = (data: any, isCurrWeek: boolean) => {
+
+    if (data.category.name === eventsCategories.garage) {
+      
+      const attValue = data.attendance.length
+      isCurrWeek ? setAtt(att + attValue) : setPrevAtt(prevAtt + attValue)
+      if (data.metaData) {
+        const givingValue = data.metaData.totalGiving
+        const mechValue = data.metaData.noOfMechanics
+        isCurrWeek ? setGiving(giving + givingValue) : setPrevGiving(prevGiving + givingValue)
+        isCurrWeek ? setMechanics(mechanics + mechValue) : setPrevMechanics(prevMechanics + mechValue)
+      }
+    }
+
+    if (data.category.name === eventsCategories.mc) {
+      const value = data.attendance.length
+      isCurrWeek ? setMcAtt(mcAtt + value) : setPrevMcAtt(prevMcAtt + value)
+    }
+
+    if (data.category.name === eventsCategories.evangelism) {
+      if (data.metaData) {
+        const value = data.metaData.noOfSalvations
+        const recomValue = data.metaData.noOfRecommitments
+        isCurrWeek ? setSalvation(salvation + value) : setPrevSalvation(prevSalvation + value)
+        isCurrWeek ? setRecom(recom + recomValue) : setPrevRecom(setPrevRecom + recomValue)
+      }
+    }
+
+    if (data.category.name === eventsCategories.baptism) {
+      if(data.metaData) {
+        const value = data.metaData.noOfBaptisms
+        isCurrWeek ? setBaptism(baptism + value) : setPrevBaptism(prevBaptism + value)
+      }
+    }
+
+    if (data.category.name === eventsCategories.wedding) {
+      isCurrWeek ? setWeddings(weddings + 1) : setPrevWeddings(prevWeddings + 1)
+    }
+  }
+
+  const getPercentage = (prev: number, current: number) => {
+    if (prev > 0) {
+      return (((current - prev) / prev) * 100)
+    }
+    return 0
+  }
+
+  const data = [
+    {
+      title: "Giving",
+      value: printMoney(giving),
+      percentage: getPercentage(prevGiving, giving),
+      icon: Money
+    },
+    {
+      title: "Attendance",
+      value: printInteger(att),
+      percentage: getPercentage(prevAtt, att),
+      icon: People
+    },
+    {
+      title: "MC Attendance",
+      value: mcAtt,
+      percentage: getPercentage(prevMcAtt, mcAtt),
+      icon: Grain
+    },
+    {
+      title: "Salvation",
+      value: salvation,
+      percentage: getPercentage(prevSalvation, salvation),
+      icon: Info
+    },
+    {
+      title: "No. of Mechanics",
+      value: mechanics,
+      percentage: getPercentage(prevMechanics, mechanics),
+      icon: Build
+    },
+    {
+      title: "No. of Baptisms",
+      value: baptism,
+      percentage: getPercentage(prevBaptism, baptism),
+      icon: EmojiPeople
+    },
+    {
+      title: "No. of Recommitments",
+      value: recom,
+      percentage: getPercentage(prevRecom, recom),
+      icon: Restore
+    },
+    {
+      title: "No. of Babies Born",
+      value: babies,
+      percentage: getPercentage(prevBabies, babies),
+      icon: ChildFriendly
+    },
+    {
+      title: "No. of Weddings",
+      value: weddings,
+      percentage: getPercentage(prevWeddings, weddings),
+      icon: LocalFlorist
+    }
+  ];
+
+  return (
+    <Grid container spacing={2}>
+      {data.map(it => (
+        <Grid item xs={12} sm={6} md={4} lg={3} key={it.title}>
+          <Widget {...it} />
+        </Grid>
+      ))}
+      <Grid item xs={12} md={6}>
+        <UsersByDevice />
+      </Grid>
+    </Grid>
+  )
+}
+
+export default DashboardData
+

--- a/src/modules/dashboard/Widget.tsx
+++ b/src/modules/dashboard/Widget.tsx
@@ -100,7 +100,7 @@ const Widget = (props: IProps) => {
                     <Typography
                         variant="caption"
                     >
-                        Since last month
+                        Since last week
                     </Typography>
                 </div>
             </CardContent>

--- a/src/modules/events/EventsList.tsx
+++ b/src/modules/events/EventsList.tsx
@@ -101,7 +101,6 @@ const toMobileRow = (data: IEvent): IMobileRow => {
         </Typography>
         <Typography variant="caption" color="textSecondary" display="block">
           Attendance: {(data.attendance.length/data.group.members.length)*100}%
-
         </Typography>
       </>
     )

--- a/src/modules/events/forms/EventForm.tsx
+++ b/src/modules/events/forms/EventForm.tsx
@@ -74,8 +74,8 @@ const EventForm = ({
       privacy: values.privacy,
       categoryId: cleanComboValue(values.category),
 
-      startDate: "2021-02-23T11:06:07.926Z",
-      endDate: "2021-02-23T11:06:07.926Z",
+      startDate: values.startDate,
+      endDate: values.endDate, 
 
       venue: parseGooglePlace(values.venue),
       groupId: cleanComboValue(values.group)
@@ -153,7 +153,7 @@ const EventForm = ({
         <Grid item xs={12} md={6}>
           <XDateTimeInput
             name="endDate"
-            label="Start Date"
+            label="End Date"
             variant="outlined"
           />
         </Grid>


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows users to see church metrics

**Description of tasks?**

- Users can now see church metrics on the Angie dashboard. Every week, the metrics are updated to highlight the metrics for that current week. A percentage change of the previous and current week is also calculated and displayed on the dashboard.

**How can I test this manually?**

- This feature requires there to be some events made for the current and previous week
- The dashboard should display the values (e.g. Giving, Salvations, Baptisms, Attendance) for the current week, as well as the percentage change from the previous week.
