### PR TITLE
Ref-023 As a cohort leader, I can see a list of all MC reports in my cohort

### DIFF
--- a/src/components/layout/NavMenu.tsx
+++ b/src/components/layout/NavMenu.tsx
@@ -65,15 +65,16 @@ const routes: IAppRoute[] = [
   },
   {
     requiredRoles: [appRoles.roleEventView, appRoles.roleEventView],
-    name: "Events",
+    name: "Reports",
     route: localRoutes.events,
-    icon: EventIcon,
+    icon: AssessmentIcon,
   },
-  {
+  /*{
+    requiredRoles: [appRoles.roleReportEdit, appRoles.roleReportView],
     name: "Reports",
     route: localRoutes.reports,
     icon: AssessmentIcon
-  },
+  },*/
   {
     requiredRoles: [appRoles.roleUserEdit, appRoles.roleUserEdit],
     name: "Admin",

--- a/src/modules/events/forms/EventForm.tsx
+++ b/src/modules/events/forms/EventForm.tsx
@@ -19,6 +19,8 @@ import { parseGooglePlace } from "../../../components/plain-inputs/PMapsInput";
 import { XMapsInput } from "../../../components/inputs/XMapsInput";
 import { IEvent } from "../types";
 import XDateTimeInput from "../../../components/inputs/XDateTimeInput";
+import { useSelector } from "react-redux";
+import { IState } from "../../../data/types";
 
 interface IProps {
   data?: Partial<IEvent>;
@@ -65,6 +67,7 @@ const EventForm = ({
   onCancel
 }: IProps) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const user = useSelector((state: IState) => state.core.user);
 
   function handleSubmit(values: any, actions: FormikHelpers<any>) {
     const toSave: any = {
@@ -73,9 +76,13 @@ const EventForm = ({
       details: values.details,
       privacy: values.privacy,
       categoryId: cleanComboValue(values.category),
+      parentId: values.group.parentId,
 
       startDate: values.startDate,
       endDate: values.endDate, 
+
+      submittedAt: new Date(),
+      submittedBy: user.contactId,
 
       venue: parseGooglePlace(values.venue),
       groupId: cleanComboValue(values.group)

--- a/src/modules/events/types.ts
+++ b/src/modules/events/types.ts
@@ -33,4 +33,13 @@ export interface IGroupEvent {
   categoryId: string;
 }
 
+export enum EventCategory {
+  WeeklyMC = "Weekly MC",
+  Garage = "Garage",
+  Evangelism = "Evangelism",
+  Wedding = "Wedding",
+  Baptism = "Baptism",
+  MC = "MC Meeting"
+}
+
 export interface MetaData {}

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -39,6 +39,14 @@ export enum GroupRole {
   Leader = "Leader"
 }
 
+export enum GroupCategory {
+  Cohort = "Cohort",
+  MC = "MC",
+  GarageTeam = "GarageTeam",
+  Huddle = "Huddle",
+  Location = "Loaction",
+}
+
 export interface IStats {
   isComplete: boolean;
   percentage: number;


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows cohort leaders to view a list of previous reports of MCs under its cohort.

**Description of tasks?**

- Cohort leaders can now see a list of MC reports from its cohort

**How can I test this manually?**

- Under `Reports` from the menu bar there should be a list of MC reports from the cohort that the logged in user is a leader of.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/113021882-b4d15a00-918c-11eb-8cc4-1bac54462663.png)
