### PR TITLE
Ref-026 As a cohort leader, I can see the total attendance for my cohort

### DIFF
--- a/src/modules/events/details/EventDetails.tsx
+++ b/src/modules/events/details/EventDetails.tsx
@@ -190,7 +190,7 @@ export default function Details() {
                   <PeopleIcon />
                 </Box>
                 <Box flexGrow={1} pt={0.5}>
-                  <GroupLink id={data.group?.name} name={data.group?.name} />
+                  <GroupLink id={data.group?.id} name={data.group?.name} />
                 </Box>
               </Box>
               <Box display="flex" pt={1}>

--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -20,12 +20,7 @@ import { grey } from "@material-ui/core/colors";
 import { get } from "../../utils/ajax";
 import { appRoles, localRoutes, remoteRoutes } from "../../data/constants";
 import Loading from "../../components/Loading";
-import {
-  Alert,
-  SpeedDial,
-  SpeedDialAction,
-  SpeedDialIcon,
-} from "@material-ui/lab";
+import { Alert, SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
 import { useHistory, useParams } from "react-router";
 import Layout from "../../components/layout/Layout";
 import MapLink from "../../components/MapLink";
@@ -263,7 +258,8 @@ export default function Details() {
               </Box>
               <Box flexGrow={1}>
                 <Typography variant="h6">{data.name}</Typography>
-                <Typography variant="body2">{`${data.privacy}, ${data.category.name}`}</Typography>
+                <Typography variant="body1">{`${data.privacy}, ${data.category.name}`}</Typography>
+                <Typography variant="overline">{`Attendance This Month: ${data.totalAttendance} (${20}%)`}</Typography>
               </Box>
 
               {isLeader() ? (

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -12,6 +12,8 @@ export interface IGroup {
   metaData?: any;
   address?: any;
   leaders?: number[];
+  children?: number[];
+  totalAttendance?: number;
 }
 
 export interface IGroupMembership {


### PR DESCRIPTION
**What does this PR do?**

This PR adds a feature that allows cohort leaders to see the total attendance of MCs under their cohort over the current month.

**Description of tasks?**

Cohort leaders can now see the total attendance for MCs under their cohort, in the current month

**How to manually test this?**

Under the `Group Details` the attendance for the current month should be visible

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/113695946-1b4cff80-96da-11eb-9cbe-5e9e271ac3cf.png)

