### PR TITLE
Ref-027 As a cohort leader, I can see the percentage of those that attended [total number of people who attended MC / total number of people in MCs] for my cohort

### DIFF
--- a/src/components/DataList.tsx
+++ b/src/components/DataList.tsx
@@ -150,7 +150,7 @@ const DataList = ({
 };
 
 export interface IMobileRow {
-  avatar: any;
+  avatar?: any;
   primary: any;
   secondary: any;
 }

--- a/src/modules/events/details/EventDetails.tsx
+++ b/src/modules/events/details/EventDetails.tsx
@@ -190,7 +190,7 @@ export default function Details() {
                   <PeopleIcon />
                 </Box>
                 <Box flexGrow={1} pt={0.5}>
-                  <GroupLink id={data.group?.name} name={data.group?.name} />
+                  <GroupLink id={data.group?.id} name={data.group?.name} />
                 </Box>
               </Box>
               <Box display="flex" pt={1}>

--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -20,12 +20,7 @@ import { grey } from "@material-ui/core/colors";
 import { get } from "../../utils/ajax";
 import { appRoles, localRoutes, remoteRoutes } from "../../data/constants";
 import Loading from "../../components/Loading";
-import {
-  Alert,
-  SpeedDial,
-  SpeedDialAction,
-  SpeedDialIcon,
-} from "@material-ui/lab";
+import { Alert, SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
 import { useHistory, useParams } from "react-router";
 import Layout from "../../components/layout/Layout";
 import MapLink from "../../components/MapLink";
@@ -263,7 +258,8 @@ export default function Details() {
               </Box>
               <Box flexGrow={1}>
                 <Typography variant="h6">{data.name}</Typography>
-                <Typography variant="body2">{`${data.privacy}, ${data.category.name}`}</Typography>
+                <Typography variant="body1">{`${data.privacy}, ${data.category.name}`}</Typography>
+                <Typography variant="overline">{`Attendance This Month: ${data.totalAttendance} (${20}%)`}</Typography>
               </Box>
 
               {isLeader() ? (

--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -85,12 +85,7 @@ const actions = [
     icon: <EventIcon color="primary" />,
     name: "New Event",
     operation: "New Event",
-  },
-  {
-    icon: <NoteAddIcon color="primary" />,
-    name: "New Report",
-    operation: "New Report",
-  },
+  }
 ];
 
 export default function Details() {
@@ -215,12 +210,10 @@ export default function Details() {
   ];
   if (isLeader()) {
     tabs.push({
-      name: "Events/Reports",
+      name: "Reports",
       component: (
         <GroupEventsList
-          groupId={Number(groupId)}
-          group={data}
-          isLeader={isLeader()}
+          childEvents={data.childEvents ? data.childEvents : []}
         />
       ),
     });
@@ -259,7 +252,7 @@ export default function Details() {
               <Box flexGrow={1}>
                 <Typography variant="h6">{data.name}</Typography>
                 <Typography variant="body1">{`${data.privacy}, ${data.category.name}`}</Typography>
-                <Typography variant="overline">{`Attendance This Month: ${data.totalAttendance} (${20}%)`}</Typography>
+                <Typography variant="overline">{`Attendance This Month: ${data.totalAttendance} (${data.averageAttendance}%)`}</Typography>
               </Box>
 
               {isLeader() ? (

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -12,6 +12,8 @@ export interface IGroup {
   metaData?: any;
   address?: any;
   leaders?: number[];
+  children?: number[];
+  totalAttendance?: number;
 }
 
 export interface IGroupMembership {

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -14,6 +14,8 @@ export interface IGroup {
   leaders?: number[];
   children?: number[];
   totalAttendance?: number;
+  averageAttendance?: string;
+  childEvents?: any[];
 }
 
 export interface IGroupMembership {

--- a/src/modules/login/ForgotPassword.tsx
+++ b/src/modules/login/ForgotPassword.tsx
@@ -10,7 +10,7 @@ import Link from '@material-ui/core/Link';
 import XTextInput from "../../components/inputs/XTextInput";
 import HelpIcon from '@material-ui/icons/Help';
 import { post } from "../../utils/ajax";
-import { isDebug, localRoutes, remoteRoutes } from "../../data/constants";
+import { isDebug, remoteRoutes } from "../../data/constants";
 import * as yup from "yup";
 import Toast from "../../utils/Toast";
 import { useHistory } from 'react-router';
@@ -24,7 +24,6 @@ export default function ForgotPassword() {
             Toast.success(`Reset Password Link Sent to Email`)
             const token = resp.token
             localStorage.setItem('password_token', token)
-            console.log(resp)
             actions.resetForm()
         }, () => {
             Toast.error(`Error: Message Not Set. Try Again Later`)

--- a/src/modules/login/ResetPassword.tsx
+++ b/src/modules/login/ResetPassword.tsx
@@ -23,13 +23,11 @@ function ResetPassword() {
         const token = localStorage.getItem('password_token')
         put(remoteRoutes.resetPassword + '/' + token, data, resp => {
             actions.resetForm()
-            console.log(resp)
             localStorage.removeItem('password_token')
             history.push(localRoutes.updatePassword)
         }, () => {
             Toast.error("Password change was unsuccessful. Try again")
             actions.setSubmitting(false)
-            console.log(token)
             actions.resetForm()
         })
     }


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows cohort leaders to see the average percentage attendance of MCs in their cohort over a month.

- This PR also fixes the report display under the Group Details page. Cohort leaders can also see the MC reports associated with their cohort.

**Description of tasks?**

- Cohort leaders can now see the average percentage attendance for MCs under their cohort, in the current month, and the reports of MCs under their cohort.

**How to manually test this?**

- Under the `Group Details` the percentage attendance for the current month should be visible. And, under the `Reports` tab, Cohort leaders should see the reports of their MCs.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/114071221-8dc00a00-98a9-11eb-9c3a-425616211890.png)

