### PR TITLE
Ref-028, As a location pastor, I can see a list of MC reports in my location

### DIFF
--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -186,7 +186,10 @@ export default function Details() {
     {
       name: "Members",
       component: (
-        <MembersList groupId={Number(groupId)} isLeader={isLeader()} />
+        <MembersList 
+          groupId={Number(groupId)} 
+          isLeader={isLeader()} 
+        />
       ),
     },
   ];
@@ -196,8 +199,8 @@ export default function Details() {
       component: (
         <GroupEventsList
           groupId={Number(groupId)}
-          group={data}
-          isLeader={isLeader()}
+          groupName={data.name}
+          groupChildren={data.children ? data.children : []}
         />
       ),
     });

--- a/src/modules/groups/GroupEventsList.tsx
+++ b/src/modules/groups/GroupEventsList.tsx
@@ -27,7 +27,6 @@ import { search } from "../../utils/ajax";
 import { Alert } from "@material-ui/lab";
 import EditDialog from "../../components/EditDialog";
 import EventForm from "../events/forms/EventForm";
-import { IGroup } from "./types";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -39,8 +38,8 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface IProps {
   groupId: number;
-  group: IGroup;
-  isLeader: boolean;
+  groupName: string;
+  groupChildren: number[];
 }
 
 const headCells: XHeadCell[] = [
@@ -68,10 +67,9 @@ const toMobileRow = (data: IEvent): IMobileRow => {
   };
 };
 
-const GroupEventsList = ({ groupId, group }: IProps) => {
+const GroupEventsList = ({ groupId, groupName, groupChildren }: IProps) => {
   const classes = useStyles();
   const history = useHistory();
-  const [event, setNewEvent] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [data, setData] = useState<IGroupEvent[]>([]);
 
@@ -80,23 +78,15 @@ const GroupEventsList = ({ groupId, group }: IProps) => {
     history.push(`${localRoutes.events}/${id}`);
   };
 
-  function handleNewEvent() {
-    setNewEvent(true);
-  }
-
-  function handleNewEventClose() {
-    setNewEvent(false);
-  }
-
   const fetchGroupEvents = useCallback(() => {
     setLoading(true);
     search(
       remoteRoutes.events,
       {
-        groupId: groupId,
+        groupIdList: groupChildren
       },
-      (data) => {
-        setData(data);
+      (resp) => {
+        setData(resp);
       },
       undefined,
       () => {
@@ -117,9 +107,9 @@ const GroupEventsList = ({ groupId, group }: IProps) => {
         <Hidden smDown>
           <Box pt={1}>
             {data.length === 0 ? (
-              <ListItem button onClick={handleNewEvent}>
+              <ListItem>
                 <Alert severity="info" style={{ width: "100%" }}>
-                  No events click to add new
+                  No reports to display
                 </Alert>
               </ListItem>
             ) : (
@@ -132,20 +122,13 @@ const GroupEventsList = ({ groupId, group }: IProps) => {
               />
             )}
           </Box>
-          <EditDialog
-            title={createTitle}
-            open={event}
-            onClose={handleNewEventClose}
-          >
-            <EventForm data={{}} isNew={true} onCreated={handleNewEventClose} />
-          </EditDialog>
         </Hidden>
         <Hidden mdUp>
           <List>
             {data.length === 0 ? (
-              <ListItem button onClick={handleNewEvent}>
+              <ListItem>
                 <Alert severity="info" style={{ width: "100%" }}>
-                  No events click to add new
+                  No reports to display
                 </Alert>
               </ListItem>
             ) : (
@@ -171,17 +154,6 @@ const GroupEventsList = ({ groupId, group }: IProps) => {
               })
             )}
           </List>
-          <EditDialog
-            title={createTitle}
-            open={event}
-            onClose={handleNewEventClose}
-          >
-            <EventForm
-              data={{ group: { id: group.id, name: group.name } }}
-              isNew={true}
-              onCreated={handleNewEventClose}
-            />
-          </EditDialog>
         </Hidden>
       </Box>
     </Grid>

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -12,6 +12,8 @@ export interface IGroup {
   metaData?: any;
   address?: any;
   leaders?: number[];
+  children?: number[];
+  parents?: number[];
 }
 
 export interface IGroupMembership {


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature that allows location pastors to view a list of reports of Missional Community events under their Location
- This PR fixes an array issue in the `findAll` events endpoint 

**Description of tasks?**
- Location pastors can now see a list of reports created by missional community leaders under their location
- The findAll events endpoint now works with arrays that have one value in them

**How can I manually test this?**
- Go to a location group’s details page. Under the `Reports` tab there should be a list of reports created by missional communities under the location.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/118628962-cd95dd80-b7d5-11eb-83cf-4fa91c82ac00.png)

