### PR TITLE
Ref-032, As a location pastor, I can see the total attendance for my Location

### DIFF
--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -236,6 +236,7 @@ export default function Details() {
               <Box flexGrow={1}>
                 <Typography variant="h6">{data.name}</Typography>
                 <Typography variant="body2">{`${data.privacy}, ${data.category.name}`}</Typography>
+                <Typography variant="body2">{`${data.name} attendance this month: ${data.totalAttendance} (${data.percentageAttendance}%)`}</Typography>
               </Box>
 
               {isLeader() ? (

--- a/src/modules/groups/GroupEventsList.tsx
+++ b/src/modules/groups/GroupEventsList.tsx
@@ -51,7 +51,7 @@ const headCells: XHeadCell[] = [
   },
   { name: "category.name", label: "Category" },
   { name: "startDate", label: "Start Date", render: printDate },
-  { name: "attendance", label: "Attendance" },
+  { name: "attendance.length", label: "Attendance" },
 ];
 
 const toMobileRow = (data: IEvent): IMobileRow => {
@@ -93,10 +93,10 @@ const GroupEventsList = ({ groupId, group }: IProps) => {
     search(
       remoteRoutes.events,
       {
-        groupId: groupId,
+        groupIdList: group.children,
       },
-      (data) => {
-        setData(data);
+      (resp) => {
+        setData(resp);
       },
       undefined,
       () => {

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -12,6 +12,10 @@ export interface IGroup {
   metaData?: any;
   address?: any;
   leaders?: number[];
+  parents?: number[];
+  children?: number[];
+  totalAttendance?: number;
+  percentageAttendance?: number;
 }
 
 export interface IGroupMembership {


### PR DESCRIPTION
**What does this PR do?**
This PR adds the feature that allows group leaders to see the total attendance and percentage attendance of the events held by groups under their group for the current month.

**Description of tasks?**
Group leaders can now see their group’s, and their children groups’, total and percentage attendance for the current month.

**How can I test this manually?**
In the groups details page, there will be a line displaying the groups total/percentage attendance. These numbers will change as group leaders add events and edit attendance for said events.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/119323853-d11ede00-bc87-11eb-83ce-822e9212865d.png)

