### PR TITLE
Code Cleanup and Refactoring

### DIFF
--- a/src/modules/dashboard/DashboardData.tsx
+++ b/src/modules/dashboard/DashboardData.tsx
@@ -11,14 +11,15 @@ import {
 import { filter } from "lodash";
 import React from "react";
 import { printInteger, printMoney } from "../../utils/numberHelpers";
-import { IEvent } from "../events/types";
+import { IEvent, IInterval } from "../events/types";
 import UsersByDevice from "./UsersByDevice";
 import Widget from "./Widget";
 import { AgField, aggregateValue, aggregateValues } from "./utils";
 
 interface IProps {
-  currWeekEvents: IEvent[];
-  prevWeekEvents: IEvent[];
+  currDataEvents: IEvent[];
+  prevDataEvents: IEvent[];
+  interval: IInterval | undefined;
 }
 
 const fields: AgField[] = [
@@ -51,15 +52,15 @@ const fields: AgField[] = [
     name: "totalGarageAttendance",
   },
 ];
-const DashboardData = ({ currWeekEvents, prevWeekEvents }: IProps) => {
-  const currentData = aggregateValues(currWeekEvents, fields);
-  const previousData = aggregateValues(prevWeekEvents, fields);
+const DashboardData = ({ currDataEvents, prevDataEvents, interval }: IProps) => {
+  const currentData = aggregateValues(currDataEvents, fields);
+  const previousData = aggregateValues(prevDataEvents, fields);
   const totalMcAttendance = aggregateValue(
-    filter(currWeekEvents, { categoryId: "mc" }),
+    filter(currDataEvents, { categoryId: "mc" }),
     "attendance"
   );
   const totalMcAttendancePrev = aggregateValue(
-    filter(prevWeekEvents, { categoryId: "mc" }),
+    filter(prevDataEvents, { categoryId: "mc" }),
     "attendance"
   );
 
@@ -139,7 +140,7 @@ const DashboardData = ({ currWeekEvents, prevWeekEvents }: IProps) => {
     <Grid container spacing={2}>
       {data.map((it) => (
         <Grid item xs={12} sm={6} md={4} lg={3} key={it.title}>
-          <Widget {...it} />
+          <Widget interval={interval}  {...it}/>
         </Grid>
       ))}
       <Grid item xs={12} md={6}>

--- a/src/modules/dashboard/DashboardFilter.tsx
+++ b/src/modules/dashboard/DashboardFilter.tsx
@@ -1,0 +1,71 @@
+import { Grid } from '@material-ui/core';
+import { lastDayOfWeek, startOfWeek } from 'date-fns/esm';
+import React from 'react';
+import PDateInput from '../../components/plain-inputs/PDateInput';
+import { PRemoteSelect } from '../../components/plain-inputs/PRemoteSelect';
+import { remoteRoutes } from '../../data/constants';
+import { useFilter } from '../../utils/fitlerUtilities';
+
+interface IProps {
+    onFilter: (data: any) => any;
+}
+
+const initialData: any = {
+    groupIdList: [],
+    from: startOfWeek(new Date()),
+    to: lastDayOfWeek(new Date()),
+    limit: 100,
+    skip: 0,
+}
+
+const DashboardFilter = ({onFilter}: IProps) => {
+
+    const { data, handleComboChange, handleDateChange } = useFilter({
+        initialData,
+        onFilter,
+        comboFields: ["groupIdList"],
+    });
+
+    return (
+        <form>
+            
+            <Grid spacing={2} container>
+                <Grid item xs={6} md>
+                  <PDateInput
+                    name="startDate"
+                    label="From"
+                    inputVariant="outlined"
+                    value={data['from']}
+                    onChange={(value) => handleDateChange("from", value)}
+                  />
+                </Grid>
+                <Grid item xs={6} md>
+                  <PDateInput
+                    name="to"
+                    label="To"
+                    inputVariant="outlined"
+                    value={data['to']}
+                    onChange={(value) => handleDateChange("to", value)}
+                  />
+                </Grid>
+                <Grid item xs={12} md>
+                  <PRemoteSelect
+                    remote={remoteRoutes.groupsCombo}
+                    name="groupIdList"
+                    label="Groups"
+                    variant="outlined"
+                    size="small"
+                    margin="none"
+                    multiple
+                    onChange={(value) => handleComboChange("groupIdList", value)}
+                    value={data['groupIdList']}
+                    searchOnline
+                  />
+                </Grid>
+              </Grid>
+            </form>
+    )
+
+}
+
+export default DashboardFilter;

--- a/src/modules/dashboard/Widget.tsx
+++ b/src/modules/dashboard/Widget.tsx
@@ -10,6 +10,7 @@ import {
 } from "@material-ui/core";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
+import { IInterval } from "../events/types";
 
 const useStyles = makeStyles((theme: Theme) => ({
     root: {
@@ -62,6 +63,7 @@ interface IProps {
     value: any
     percentage: number
     icon: any
+    interval: IInterval | undefined
 }
 
 const Widget = (props: IProps) => {
@@ -84,7 +86,7 @@ const Widget = (props: IProps) => {
                         >
                             {props.title.toLocaleUpperCase()}
                         </Typography>
-                        <Typography variant="h6">{props.value}</Typography>
+                        <Typography variant="h6">{Number(props.value)}</Typography>
                     </Grid>
                     <Grid item>
                         <Avatar className={props.percentage < 0 ? classes.avatar : classes.avatarPlus}>
@@ -102,12 +104,12 @@ const Widget = (props: IProps) => {
                         className={props.percentage < 0 ? classes.differenceValue : classes.positiveValue}
                         variant="body2"
                     >
-                        {props.percentage}%
+                        {Number(props.percentage.toFixed(2))}%
                     </Typography>
                     <Typography
                         variant="caption"
                     >
-                        Since last week
+                        {`${props.interval?.from} - ${props.interval?.to}`}
                     </Typography>
                 </div>
             </CardContent>

--- a/src/modules/events/types.ts
+++ b/src/modules/events/types.ts
@@ -44,3 +44,8 @@ export enum EventCategory {
 }
 
 export interface MetaData {}
+
+export interface IInterval {
+  from: Date | string;
+  to: Date | string;
+}

--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -9,7 +9,7 @@ import PinDropIcon from "@material-ui/icons/PinDrop";
 import PeopleIcon from "@material-ui/icons/People";
 import Typography from "@material-ui/core/Typography";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
-import { Theme } from "@material-ui/core";
+import { Button, ButtonGroup, Hidden, Theme } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
 import Divider from "@material-ui/core/Divider";
 import EditIcon from "@material-ui/icons/Edit";
@@ -243,34 +243,58 @@ export default function Details() {
               </Box>
 
               {isLeader() ? (
-                <Box pr={2} flexGrow={1}>
-                  <SpeedDial
-                    ariaLabel="SpeedDial"
-                    className={classes.speedDial}
-                    icon={<SpeedDialIcon />}
-                    onClose={handleDialClose}
-                    onOpen={handleDialOpen}
-                    onClick={handleIconClick}
-                    open={open}
-                    direction="down"
-                    color="primary"
-                    FabProps={{
-                      size: "small",
-                    }}
-                  >
-                    {actions.map((action) => (
-                      <SpeedDialAction
-                        key={action.name}
-                        icon={action.icon}
-                        tooltipTitle={action.name}
-                        tooltipPlacement="left"
-                        onClick={() => {
-                          handleIconClick(action.operation);
-                        }}
-                      />
-                    ))}
-                  </SpeedDial>
-                </Box>
+                <>
+                  <Hidden smDown>
+                    <Box pr={2}>
+                      <ButtonGroup variant="contained">
+                        <Button
+                          color="primary"
+                          size="small"
+                          variant="contained"
+                          onClick={handleEdit}
+                        >
+                          Edit Group&nbsp;&nbsp;
+                        </Button>
+                        <Button
+                          color="primary"
+                          size="small"
+                          variant="contained"
+                          onClick={handleNewEvent}
+                        >
+                          Create Report&nbsp;&nbsp;
+                        </Button>
+                      </ButtonGroup>
+                    </Box>
+                  </Hidden>
+                  <Hidden mdUp>
+                    <SpeedDial
+                      ariaLabel="SpeedDial"
+                      className={classes.speedDial}
+                      icon={<SpeedDialIcon />}
+                      onClose={handleDialClose}
+                      onOpen={handleDialOpen}
+                      onClick={handleIconClick}
+                      open={open}
+                      direction="down"
+                      color="primary"
+                      FabProps={{
+                        size: "small",
+                      }}
+                    >
+                      {actions.map((action) => (
+                        <SpeedDialAction
+                          key={action.name}
+                          icon={action.icon}
+                          tooltipTitle={action.name}
+                          tooltipPlacement="left"
+                          onClick={() => {
+                            handleIconClick(action.operation);
+                          }}
+                        />
+                      ))}
+                    </SpeedDial>
+                  </Hidden>
+                </>
               ) : null}
             </Box>
             <Divider />


### PR DESCRIPTION
**What does this PR do?**
- This PR adds the feature that allows users to filter the data displayed on the dashboard by date and group.
- This PR splits the `Edit Group` and `Create Report` buttons on the Groups details page. The speed dial will only show when the user is using a mobile device.

**Description of tasks?**
- Users can now filter the data being displayed on the dashboard. This satisfies a scenario where a user may only want to look at dashboard data for a specific group(s) or data between two dates. 

**How can I test this manually?**
- On the dashboard, select a start date, end date and specific groups. The dashboard should only display data that meets the criteria of the filter.

**Screenshot(s)**
![Screen Shot 2021-06-07 at 4 09 10 PM](https://user-images.githubusercontent.com/68650343/121022260-d82b0d80-c7aa-11eb-84a4-421c7c7fd1b1.png)
![Screen Shot 2021-06-07 at 4 09 34 PM](https://user-images.githubusercontent.com/68650343/121022284-dcefc180-c7aa-11eb-9cee-77b955e36997.png)
