### PR TITLE
Fix-015. Tapping Profile in the top right menu should lead to My Profile

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -3,39 +3,24 @@ import IconButton from "@material-ui/core/IconButton";
 import AccountCircle from "@material-ui/icons/AccountCircle";
 import MenuItem from "@material-ui/core/MenuItem";
 import Menu from "@material-ui/core/Menu";
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
 import Typography from "@material-ui/core/Typography";
-import ListItemAvatar from "@material-ui/core/ListItemAvatar";
-import Dialog from "@material-ui/core/Dialog";
-import PersonIcon from "@material-ui/icons/Person";
-import Avatar from "@material-ui/core/Avatar";
 import { useDispatch, useSelector } from "react-redux";
 import { IState } from "../data/types";
-import ListItemIcon from "@material-ui/core/ListItemIcon";
-import ListItemText from "@material-ui/core/ListItemText";
-import MailIcon from "@material-ui/icons/Mail";
 import HiddenJs from "@material-ui/core/Hidden/HiddenJs";
 import { getInitials } from "../utils/stringHelpers";
 import { handleLogout } from "../data/coreActions";
+import { useHistory } from "react-router";
+import { localRoutes } from "../data/constants";
 
 export const BarView = (props: any) => {
     const profile = useSelector((state: IState) => state.core.user)
     const dispatch = useDispatch();
-    const [dialogOpen, setDialogOpen] = useState(false);
+    const history = useHistory();
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const menuOpen = Boolean(anchorEl);
 
-    function openDialog() {
-        setDialogOpen(true)
-    }
-
     function doLogout() {
         dispatch(handleLogout())
-    }
-
-    function closeDialog() {
-        setDialogOpen(false)
     }
 
     function handleMenu(event: React.MouseEvent<HTMLElement>) {
@@ -44,6 +29,10 @@ export const BarView = (props: any) => {
 
     function handleCloseMenu() {
         setAnchorEl(null);
+    }
+
+    function goToProfile() {
+        history.push(localRoutes.profile)
     }
 
     return <div>
@@ -78,26 +67,8 @@ export const BarView = (props: any) => {
             open={menuOpen}
             onClose={handleCloseMenu}
         >
-            <MenuItem onClick={openDialog}>Profile</MenuItem>
+            <MenuItem onClick={goToProfile}>Profile</MenuItem>
             <MenuItem onClick={doLogout}>Logout</MenuItem>
         </Menu>
-        <Dialog onClose={closeDialog} aria-labelledby="simple-dialog-title" open={dialogOpen}>
-            <List>
-                <ListItem>
-                    <ListItemAvatar>
-                        <Avatar>
-                            <PersonIcon/>
-                        </Avatar>
-                    </ListItemAvatar>
-                    <ListItemText primary={profile.fullName}/>
-                </ListItem>
-                <ListItem button>
-                    <ListItemIcon>
-                        <MailIcon/>
-                    </ListItemIcon>
-                    <ListItemText primary={profile.email}/>
-                </ListItem>
-            </List>
-        </Dialog>
     </div>
 }


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature where when `Profile`, in the top right menu, is clicked, it sends the user to their `My Profile` page. 