### PR TITLE
Fix-012. Report data loading error

### DIFF
--- a/src/modules/events/details/EventDetails.tsx
+++ b/src/modules/events/details/EventDetails.tsx
@@ -100,26 +100,28 @@ export default function Details() {
     dispatch(eventsEdit(dt));
   }
 
-  if (loading)
+  if (loading) {
     return (
       <Layout>
         <Loading />
       </Layout>
     );
-
-  if (!data)
-    return (
-      <Layout>
-        <Box
-          p={4}
-          className={classes.root}
-          display="flex"
-          justifyContent="center"
-        >
-          <Alert severity="error">Failed to load report data</Alert>
-        </Box>
-      </Layout>
-    );
+  } else {
+    if (!data) {
+      return (
+        <Layout>
+          <Box
+            p={4}
+            className={classes.root}
+            display="flex"
+            justifyContent="center"
+          >
+            <Alert severity="error">Failed to load report data</Alert>
+          </Box>
+        </Layout>
+      );
+    }
+  }
 
   function handleDeleted() {
     history.push(localRoutes.groups);


### PR DESCRIPTION
**What does this PR do?**
- This PR fixes the `Failed to Load Data` error that displays, for a second, when users goes the the report details page.