### PR TITLE
Fix-018. Add link to YouTube Tutorials to the Help page

### DIFF
--- a/src/modules/ContentSwitch.tsx
+++ b/src/modules/ContentSwitch.tsx
@@ -17,6 +17,7 @@ import UpdatePasswordConfirmation from "./login/UpdatePasswordConfirmation";
 import EventDetails from "./events/details/EventDetails";
 import Events from "./events/EventsList";
 import GroupReports from "./events/GroupReports";
+import Help from "./help/Help";
 
 const ContentSwitch = () => {
   const user = useSelector((state: IState) => state.core.user);
@@ -53,10 +54,8 @@ const ContentSwitch = () => {
 
       <Route path={localRoutes.settings} component={Settings} />
       <Route path={localRoutes.test} component={Testing} />
-      <Route
-        path={localRoutes.updatePassword}
-        component={UpdatePasswordConfirmation}
-      />
+      <Route path={localRoutes.updatePassword} component={UpdatePasswordConfirmation} />
+      <Route path={localRoutes.help} component={Help} />
       <Route component={NoMatch} />
     </Switch>
   );

--- a/src/modules/help/Help.tsx
+++ b/src/modules/help/Help.tsx
@@ -1,0 +1,66 @@
+import { createStyles, Link, makeStyles } from '@material-ui/core';
+import { Theme } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
+import React from 'react';
+import XBreadCrumbs from '../../components/XBreadCrumbs';
+import { localRoutes } from '../../data/constants';
+import Layout from "./../../components/layout/Layout";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: "100%",
+      padding: theme.spacing(2),
+      [theme.breakpoints.up("sm")]: {
+        padding: theme.spacing(1),
+      },
+    },
+    links: {
+        margin: theme.spacing(2)
+    }
+  })
+);
+
+const Help = () => {
+    const classes = useStyles();
+    const preventDefault = (event: React.SyntheticEvent) => event.preventDefault;
+
+    return (
+        <Layout>
+            <Box className={classes.root}>
+                <Box pb={2}>
+                    <XBreadCrumbs
+                        title="Help Center"
+                        paths={[
+                            {
+                                path: localRoutes.home,
+                                label: "Dashboard"
+                            }
+                        ]}
+                    />
+                </Box>
+                <Typography variant='h4'>Tutorial Videos</Typography>
+                <Box className={classes.links}>
+                    <Link href="https://youtu.be/q0G3pAVD2Zg" onClick={preventDefault} variant="h6">
+                        How to register as a visitor and approve members as an administrator.
+                    </Link>
+                    <br/>
+                    <Link href="https://youtu.be/PtRNvkcFBP0" onClick={preventDefault} variant="h6">
+                        How to manage your personal details
+                    </Link>
+                    <br/>
+                    <Link href="https://youtu.be/gqKYO5XAb38" onClick={preventDefault} variant="h6">
+                        How to manage group details and add, edit and remove members
+                    </Link>
+                    <br/>
+                    <Link href="https://youtu.be/yvDth5gPrxk" onClick={preventDefault} variant="h6">
+                        How to upload a list of members using a csv file 
+                    </Link>
+                    <br/>
+                </Box>
+            </Box> 
+        </Layout>
+    )
+}
+
+export default Help;


### PR DESCRIPTION
**What does this PR do?**
- This PR adds the links to the Youtube tutorial videos in the Help page

**Description of tasks?**
- Users can now find the a links to Youtube tutorial videos in the `Help` menu link

**Screenshot(s)**
![Screen Shot 2021-06-16 at 2 25 33 PM](https://user-images.githubusercontent.com/68650343/122211150-16ad8000-ceaf-11eb-8d6b-7dcdb3ee5eb4.png)
