### PR TITLE
Fix-010. Display password criteria when user is setting or updating password

### DIFF
--- a/src/modules/settings/PasswordReset.tsx
+++ b/src/modules/settings/PasswordReset.tsx
@@ -1,9 +1,17 @@
 import React, { useState } from "react";
-import { Button, Card, CardContent, TextField } from "@material-ui/core";
+import { Card, CardContent, Typography } from "@material-ui/core";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import XHeader from "../../components/ibox/XHeader";
-import Box from "@material-ui/core/Box";
 import CenteredDiv from "../../components/CenteredDiv";
+import XForm from "../../components/forms/XForm";
+import XTextInput from "../../components/inputs/XTextInput";
+import Toast from "../../utils/Toast";
+import { FormikHelpers } from "formik";
+import { useSelector } from "react-redux";
+import { IState } from "../../data/types";
+import { handleSubmission, ISubmission } from "../../utils/formHelpers";
+import { remoteRoutes } from "../../data/constants";
+import * as yup from 'yup';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -15,60 +23,78 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const PasswordReset = () => {
   const classes = useStyles();
+  const user = useSelector((state: IState) => state.core.user);
+  const [passwordOne, setPasswordOne] = useState("");
+  const [passwordTwo, setPasswordTwo] = useState("");
+  const [isLength, setIsLength] = useState<boolean>(false);
+  const [isMatch, setIsMatch] = useState<boolean>(false);
+  const lengthCheck = yup.string()
+    .required("Password is required")
+    .min(8, 'Password is too short - should be 8 characters minimum.');
+  
+  const handleChangeOne = (e: any) => {
+    setPasswordOne(e.target.value)
+  }
 
-  const [values, setValues] = useState({
-    password: "",
-    confirm: ""
-  });
+  const handleChangeTwo = (e: any) => {
+    setPasswordTwo(e.target.value)
+  }
 
-  const handleChange = (event: any) => {
-    setValues({
-      ...values,
-      [event.target.name]: event.target.value
-    });
-  };
+  async function validation() {
+    setIsLength(await lengthCheck.isValid(passwordOne))
+    setIsMatch(passwordOne === passwordTwo)
+  }
+
+  function handleSubmit(values: any, actions: FormikHelpers<any>) {
+
+   if (isMatch && isLength) {
+      const toSave = {
+        id: user.id,
+        roles: user.roles,
+        password: values.confirmPassword
+      }
+      const submission: ISubmission = {
+        url: remoteRoutes.users,
+        values: toSave,
+        actions,
+        isNew: false,
+      };
+      handleSubmission(submission)
+    } else {
+      Toast.error("Your Password Does Not Meet The Criteria Below")
+      actions.resetForm();
+    }
+  }
 
   return (
     <Card className={classes.root} elevation={0}>
       <XHeader title="Update Password" />
       <CardContent>
         <CenteredDiv width={300}>
-          <form>
-            <TextField
-              fullWidth
-              label="Old Password"
-              name="oldPassword"
-              onChange={handleChange}
-              type="password"
-              value={values.password}
-              variant="outlined"
-            />
-            <TextField
-              fullWidth
+          <XForm
+            onSubmit={handleSubmit}
+          >
+            <XTextInput 
               label="New Password"
               name="newPassword"
-              onChange={handleChange}
               type="password"
-              value={values.password}
+              onChangeCapture={handleChangeOne}
+              onKeyUp={validation}
               variant="outlined"
               style={{ marginTop: "1rem" }}
             />
-            <TextField
-              fullWidth
-              label="Confirm password"
-              name="confirm"
-              onChange={handleChange}
-              style={{ marginTop: "1rem" }}
+            <XTextInput 
+              label="Confirm Password"
+              name="confirmPassword"
               type="password"
-              value={values.confirm}
+              onChangeCapture={handleChangeTwo}
+              onKeyUp={validation}
               variant="outlined"
+              style={{ marginTop: "1rem" }}
             />
-            <Box display="flex" justifyContent="flex-end" pt={2}>
-              <Button color="primary" variant="outlined">
-                Update
-              </Button>
-            </Box>
-          </form>
+            <Typography variant="body2" style={{color: isLength ? "green" : "red"}}>Password must be 8 characters long</Typography> 
+            <Typography variant="body2" style={{color: isMatch ? "green" : "red"}}>Passwords must match</Typography>
+          </XForm>
         </CenteredDiv>
       </CardContent>
     </Card>


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature that allows users to see when their password has met the password criteria.
- This PR also satisfies **_Fix-014. Updating user credentials_**

**Description of task?**
- Under every set password form, there will be a list of criteria that the user's password must meet. Failure to meet these requirements will result in an error.
- There is also frontend validation check, to ensure that information sent to the backend is proper.

**How can I test this manually?**
- Under a set password form, there will be a list of criteria that the password must meet. As the user enters their password, each criteria met will turn green, while criteria not met will remain red.

**Screenshot(s)**
![Screen Shot 2021-06-17 at 3 02 22 AM](https://user-images.githubusercontent.com/68650343/122310324-c8cd6200-cf18-11eb-9eb9-f8e6061e97bd.png)
